### PR TITLE
added chaste mark for skipping chaste tests

### DIFF
--- a/weblab_cg/tests/test_chaste_cg.py
+++ b/weblab_cg/tests/test_chaste_cg.py
@@ -12,6 +12,12 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers', 'env(chaste): tests specific for chaste code gen, exclude these with pytest -m "not chaste"'
+    )
+
+
 def model_types():
     return ['Normal']
 
@@ -27,6 +33,7 @@ class TestChasteCG(object):
     TODO: unit conversion vvia cellmlmanip once implemented"""
     _TIMESTAMP_REGEX = re.compile(r'(//! on .*\n)')
 
+    @pytest.mark.chaste
     @pytest.mark.parametrize(('model'), chaste_models())
     def test_generate_chaste_model(self, tmp_path, model):
         """ Check generation of Normal models against reference"""
@@ -55,6 +62,7 @@ class TestChasteCG(object):
             assert expected_hpp == generated_hpp
             assert expected_cpp == generated_cpp
 
+    @pytest.mark.chaste
     def test_generate_dymaic_chaste_model(self, tmp_path):
         tmp_path = str(tmp_path)
         LOGGER.info('Converting: Normal Dynamichodgkin_huxley_squid_axon_model_1952_modified\n')

--- a/weblab_cg/tests/test_chaste_cg.py
+++ b/weblab_cg/tests/test_chaste_cg.py
@@ -13,6 +13,7 @@ LOGGER.setLevel(logging.DEBUG)
 
 
 def pytest_configure(config):
+    """ Sets up pytest configuration programatically and adds pytest marks so we can use the, below."""
     config.addinivalue_line(
         'markers', 'env(chaste): tests specific for chaste code gen, exclude these with pytest -m "not chaste"'
     )

--- a/weblab_cg/tests/test_chaste_cg_develop.py
+++ b/weblab_cg/tests/test_chaste_cg_develop.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
 
-class TestChasteCG(object):
+class TestChasteCGDevelop(object):
     """ Tests to help development of weblab_cg. This test compares symbolically against pycml reference output
 
     # TODO: Better docstrings"""
@@ -34,6 +34,7 @@ class TestChasteCG(object):
                                   ref_path_prefix=['chaste_reference_models', 'develop'], class_name_prefix='Dynamic')
 
     @pytest.mark.skip(reason="This test is a development tool")
+    @pytest.mark.chaste
     def test_generate_chaste_models_develop(self, tmp_path, chaste_models):
         """ Check generation of Normal models against reference"""
         tmp_path = str(tmp_path)


### PR DESCRIPTION
## Description
This change adds a chaste mark so you can exclude the (slow) chaste tests by using `pytest -m "not chaste"`

## Motivation and Context
We're looking for a way to make the chaste test slowness less frustrating for @MichaelClerx during development. Suggested by @jonc125  in #45

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation necessary.
- [X] I have checked spelling in (new) comments.

##Testing
- [X] Testing is done automaticly and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

